### PR TITLE
Updating pi.valid_url.php to fix php warning with usage() function

### DIFF
--- a/valid_url/pi.valid_url.php
+++ b/valid_url/pi.valid_url.php
@@ -125,7 +125,7 @@ class Valid_url {
 	 * @access	public
 	 * @return	string
 	 */
-	function usage()
+	public static function usage()
 	{
 		return <<<ONESY
 		Makes sure that a URL has a protocol, that ampersands are converted to entities, and all


### PR DESCRIPTION
Since the way the usage() function is declared changed in EE 2.8.1 'function usage()' needs to change to 'public static function usage()'.
